### PR TITLE
add "(indiv)" children to nodes with non-negligible indivual time/alloc

### DIFF
--- a/src/Profiteur/Core.hs
+++ b/src/Profiteur/Core.hs
@@ -61,8 +61,11 @@ mkCostCentreMap = go HMS.empty
         forIndiv (HMS.insert (T.pack $ show $ ccnId indiv) indiv) $
         HMS.insert (T.pack $ show $ ccnId ccn) ccn{ccnChildren=forIndiv (V.cons indiv) $ ccnChildren ccn} $
         V.foldl' go ccm $ ccnChildren ccn
-      where forIndiv f | cciIndividualTime i < 1e-6 && cciIndividualAlloc i < 1e-6 = id
-                       | otherwise = f
+      where forIndiv f |    cciIndividualTime i > 1e-6
+                         && cciIndividualAlloc i > 1e-6
+                         && not (V.null (ccnChildren ccn)) = f
+
+                       | otherwise = id
             indiv = CostCentreNode
               { ccnName     = new_name
               , ccnId       = 1000000 + ccnId ccn

--- a/src/Profiteur/Core.hs
+++ b/src/Profiteur/Core.hs
@@ -58,8 +58,22 @@ mkCostCentreMap = go HMS.empty
   where
     go :: CostCentreMap -> CostCentreNode -> CostCentreMap
     go ccm !ccn =
-        HMS.insert (T.pack $ show $ ccnId ccn) ccn $
-        V.foldl' go ccm (ccnChildren ccn)
+        forIndiv (HMS.insert (T.pack $ show $ ccnId indiv) indiv) $
+        HMS.insert (T.pack $ show $ ccnId ccn) ccn{ccnChildren=forIndiv (V.cons indiv) $ ccnChildren ccn} $
+        V.foldl' go ccm $ ccnChildren ccn
+      where forIndiv f | cciIndividualTime i < 1e-6 && cciIndividualAlloc i < 1e-6 = id
+                       | otherwise = f
+            indiv = CostCentreNode
+              { ccnName     = new_name
+              , ccnId       = 1000000 + ccnId ccn
+              , ccnInfo     = new_info
+              , ccnChildren = V.empty
+              }
+            new_name = let n = ccnName ccn
+                           t = T.pack " (indiv)" `T.append` nCanonical n in
+              n{nCanonical=t}
+            i = ccnInfo ccn
+            new_info = i{cciInheritedTime=cciIndividualTime i,cciInheritedAlloc=cciIndividualAlloc i}
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Fantastic tool. Thanks very much!

One behavior that I find burdensome when using the tool is that a node's individual time and alloc vanish when I expand it. This causes me some confusion.

This commit "fixes" that behavior (IMO) by adding a dummy child to each proper node. The new dummy node has the same individual time and alloc as its parent, so that that information persists in the visualization.

In other words, the size of the rectangles in the treemap now all use the same global scale no matter how many nodes have been expanded.

I invite others to clean-up this code: add comments, guard this behavior with a command-line switch, do something more reasonable than the "1000000" literal, etc.

Thanks again for a great tool!