### PR TITLE
bump versions of aeson and attoparsec

### DIFF
--- a/profiteur.cabal
+++ b/profiteur.cabal
@@ -48,8 +48,8 @@ Executable profiteur
 
   Build-depends:
     base                 >= 4    && < 5,
-    aeson                >= 0.6  && < 0.9,
-    attoparsec           >= 0.10 && < 0.13,
+    aeson                >= 0.6  && < 0.10,
+    attoparsec           >= 0.10 && < 0.14,
     bytestring           >= 0.9  && < 0.11,
     text                 >= 0.11 && < 1.3,
     filepath             >= 1.3  && < 1.5,


### PR DESCRIPTION
This seems to compile fine with ghc-7.10 at least.