### PR TITLE
Needs GHC >= 7.10 due to Prelude.(<$>)

### DIFF
--- a/profiteur.cabal
+++ b/profiteur.cabal
@@ -45,7 +45,7 @@ Executable profiteur
     Profiteur.Parser
 
   Build-depends:
-    base                 >= 4    && < 5,
+    base                 >= 4.8  && < 5,
     aeson                >= 0.6  && < 0.11,
     attoparsec           >= 0.10 && < 0.14,
     bytestring           >= 0.9  && < 0.11,


### PR DESCRIPTION
```
src/Profiteur/Core.hs:75:30:
    Not in scope: ‘<$>’
    Perhaps you meant ‘<>’ (imported from Data.Monoid)
```

This only applies to the latest version. I added a revision (https://hackage.haskell.org/package/profiteur-0.3.0.0/revisions/) so a new release is only necessary if you wish to restore backwards compatibility.


