### PR TITLE
Add readme to extra-source-files

### DIFF
--- a/profiteur.cabal
+++ b/profiteur.cabal
@@ -14,6 +14,7 @@ Cabal-version:       >= 1.8
 
 Extra-source-files:
   CHANGELOG
+  README.markdown
 
 Data-files:
   data/css/main.css


### PR DESCRIPTION
Hackage displays readmes nowadays, so the file should be included in the package