### PR TITLE
Use HSL instead of RGB for color generation

### DIFF
--- a/data/js/node.js
+++ b/data/js/node.js
@@ -85,29 +85,10 @@ Node.prototype.getColor = function() {
         hash = (hash << 5) + hash + str.charCodeAt(i);
     }
 
-    hash = hash % 0xffffff;
-    var r = (hash & 0xff0000) >> 16;
-    var g = (hash & 0x00ff00) >> 8;
-    var b = (hash & 0x0000ff);
-
-    r = (r) / 2;
-    g = (g) / 2;
-    b = (b) / 2;
-
-    function hex2(x) {
-        var str = x.toString(16);
-        if (str.length < 2) {
-            for (var i = 0; i < 2 - str.length; i++) {
-                str = '0' + str;
-            }
-        }
-        return str;
-    }
-
-    return '#' +
-        hex2(Math.round(r)) +
-        hex2(Math.round(g)) +
-        hex2(Math.round(b));
+    var h = hash % 360;
+    var s = "100%";
+    var l = "40%";
+    return 'hsl(' + h + ', ' + s + ', ' + l + ')';
 };
 
 Node.prototype.getCost = function() {

--- a/data/js/tree-map.js
+++ b/data/js/tree-map.js
@@ -219,6 +219,8 @@ TreeMap.prototype.renderNode = function(node) {
     // Fill entire area
     context.fillStyle = node.getColor();
     context.fillRect(rect.x, rect.y, rect.w, rect.h);
+    context.strokeStyle = 'black';
+    context.strokeRect(rect.x, rect.y, rect.w, rect.h);
 
     // Draw children on top.
     if (node.children.length > 0) {


### PR DESCRIPTION
By using `hsl(…)` instead of manually generating a hex string, we can remove a lot of the bit twiddling, and also get a nicer distribution of colors. Vary the `l` parameter to adjust brightness to your liking.

I also added a black stroke so adjacent, but similarly colored, areas are more distinguishable.

![selection_005](https://user-images.githubusercontent.com/3020161/27002163-f6867836-4dd9-11e7-866d-ee3540401d63.png)

