### PR TITLE
changed: deincrement saturation and lightness

### DIFF
--- a/data/css/main.css
+++ b/data/css/main.css
@@ -5,7 +5,7 @@ html {
     font-family:      sans-serif;
     font-size:        14px;
     background-color: #222;
-    color:            #ddd;
+    color:            white;
     overflow:         hidden;
 }
 

--- a/data/js/node.js
+++ b/data/js/node.js
@@ -86,8 +86,8 @@ Node.prototype.getColor = function() {
     }
 
     var h = hash % 360;
-    var s = "30%";
-    var l = "30%";
+    var s = "50%";
+    var l = "40%";
     return 'hsl(' + h + ', ' + s + ', ' + l + ')';
 };
 

--- a/data/js/node.js
+++ b/data/js/node.js
@@ -86,8 +86,8 @@ Node.prototype.getColor = function() {
     }
 
     var h = hash % 360;
-    var s = "100%";
-    var l = "40%";
+    var s = "30%";
+    var l = "30%";
     return 'hsl(' + h + ', ' + s + ', ' + l + ')';
 };
 


### PR DESCRIPTION
I can not read character of saturation high yellow background color.
![screenshot-2018-02-27-19-34-12](https://user-images.githubusercontent.com/2913112/36724688-4527ee3e-1bf7-11e8-9283-a348b6643a74.png)

I think there are various opinions about numerical values.
100 and 40 will not work with the current algorithm.
I can not read the characters.