### PR TITLE
deleted: depends upper limit

### DIFF
--- a/profiteur.cabal
+++ b/profiteur.cabal
@@ -53,21 +53,21 @@ Executable profiteur
     Paths_profiteur
 
   Build-depends:
-    aeson                >= 0.6  && < 1.3,
-    base                 >= 4.8  && < 5,
-    bytestring           >= 0.9  && < 0.11,
-    containers           >= 0.5  && < 0.6,
-    filepath             >= 1.3  && < 1.5,
-    ghc-prof             >= 1.3  && < 1.5,
-    js-jquery            >= 3.1  && < 3.3,
-    scientific           >= 0.3  && < 0.4,
-    text                 >= 0.11 && < 1.3,
-    unordered-containers >= 0.2  && < 0.3,
-    vector               >= 0.10 && < 0.13
+    aeson                >= 0.6,
+    base                 >= 4.8,
+    bytestring           >= 0.9,
+    containers           >= 0.5,
+    filepath             >= 1.3,
+    ghc-prof             >= 1.3,
+    js-jquery            >= 3.1,
+    scientific           >= 0.3,
+    text                 >= 0.11,
+    unordered-containers >= 0.2,
+    vector               >= 0.10
 
   if flag(embed-data-files)
-    Build-depends: file-embed >= 0.0.10 && < 0.0.11,
-                   template-haskell >= 2.11 && < 2.12
+    Build-depends: file-embed >= 0.0.10,
+                   template-haskell >= 2.11
     Hs-source-dirs: src/embed
   else
     Hs-source-dirs: src/noembed

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,1 @@
-resolver: nightly-2017-12-14
-extra-package-dbs: []
-extra-deps: []
-packages:
-  - '.'
+resolver: lts-11.8


### PR DESCRIPTION
js-jquery is 3.3.1 on the stackage.
So, profiteur remove from stackage.
This commit delegate depends management to stackage.

@jaspervdj If merge this pull request, please edit [stackage/build-constraints.yaml at master · fpco/stackage](https://github.com/fpco/stackage/blob/master/build-constraints.yaml)