### PR TITLE
Relax version constraints for embed-data-files dependencies

### DIFF
--- a/profiteur.cabal
+++ b/profiteur.cabal
@@ -68,7 +68,7 @@ Executable profiteur
   if flag(embed-data-files)
     Hs-source-dirs: src/embed
     Build-depends:
-      file-embed       >= 0.0.10 && < 0.0.11,
-      template-haskell >= 2.11   && < 2.12
+      file-embed       >= 0.0.10 && < 0.0.12,
+      template-haskell
   else
     Hs-source-dirs: src/noembed


### PR DESCRIPTION
Note: I opted to remove `template-haskell` version bounds completely because the package itself only depends on the `runIO` function from `Language.Haskell.TH`, which is, frankly, extremely unlikely to change, and it has been there basically since forever (i.e. GHC 6.10)

`template-haskell` version is additionally constrained by `base` version. Long story short, `base >= 4.8` translates to `template-haskell >= 2.10`.

`template-haskell-2.10`, will work fine here (basically I messed up when writing version constraints the last time)