### PR TITLE
Add source locations to cost-centre details

### DIFF
--- a/data/js/details.js
+++ b/data/js/details.js
@@ -57,6 +57,10 @@ Details.prototype.mkElement = function() {
             .append(mk('td').text('Alloc'))
             .append(mk('td').addClass('alloc')));
 
+    table.append(mk('tr')
+            .append(mk('td').text('Src'))
+            .append(mk('td').append(mk('code').addClass('src'))));
+
     table.append(mk('tr').addClass('mainTimeRow')
             .append(mk('td').text('MAIN Time'))
             .append(mk('td').addClass('mainTime')));
@@ -125,6 +129,7 @@ Details.prototype.render = function(node) {
     this.container.find('.entries').text(node.getEntries());
     this.container.find('.time').text(formatNum(time));
     this.container.find('.alloc').text(formatNum(alloc));
+    this.container.find('.src').text(node.getSourceLoc().replace(/(^<|>$)/g, ""));
     this.container.find('.mainTime').text(formatNum(mainTime));
     this.container.find('.mainAlloc').text(formatNum(mainAlloc));
 

--- a/data/js/node.js
+++ b/data/js/node.js
@@ -17,10 +17,11 @@ function Node(prof, selection, sorting, parent, id) {
     var data = prof[id];
     _this.name     = data[0];
     _this.module   = data[1];
-    _this.entries  = data[2];
-    _this.time     = data[3];
-    _this.alloc    = data[4];
-    _this.childIds = data[5];
+    _this.src      = data[2];
+    _this.entries  = data[3];
+    _this.time     = data[4];
+    _this.alloc    = data[5];
+    _this.childIds = data[6];
     _this.children = [];
 
     if (sorting) sorting.addChangeListener(_this);
@@ -72,6 +73,10 @@ Node.prototype.getModuleName = function() {
 
 Node.prototype.getFullName = function() {
     return this.module + '.' + this.name;
+};
+
+Node.prototype.getSourceLoc = function() {
+    return this.src;
 };
 
 Node.prototype.getEntries = function() {

--- a/src/Profiteur/Core.hs
+++ b/src/Profiteur/Core.hs
@@ -32,6 +32,7 @@ type Id = T.Text
 data CostCentre = CostCentre
     { ccName            :: !T.Text
     , ccModule          :: !T.Text
+    , ccSrc             :: !T.Text
     , ccId              :: !Id
     , ccEntries         :: !Int
     , ccIndividualTime  :: !Double
@@ -47,6 +48,7 @@ data Node = Node
     { nId       :: !Id
     , nName     :: !T.Text
     , nModule   :: !T.Text
+    , nSrc      :: !T.Text
     , nEntries  :: !Int
     , nTime     :: !Double
     , nAlloc    :: !Double
@@ -72,6 +74,7 @@ nodesFromCostCentre cc
                 { nId       = ccId cc
                 , nName     = ccName cc
                 , nModule   = ccModule cc
+                , nSrc      = ccSrc cc
                 , nEntries  = ccEntries cc
                 , nTime     = ccInheritedTime cc
                 , nAlloc    = ccInheritedAlloc cc
@@ -87,6 +90,7 @@ nodesFromCostCentre cc
             { nId       = ccId cc <> ".indiv"
             , nName     = ccName cc <> " (indiv)"
             , nModule   = ccModule cc
+            , nSrc      = ccSrc cc
             , nEntries  = ccEntries cc
             , nTime     = ccIndividualTime cc
             , nAlloc    = ccIndividualAlloc cc
@@ -99,6 +103,7 @@ instance A.ToJSON Node where
     toJSON Node {..} = A.toJSON
         [ A.toJSON nName
         , A.toJSON nModule
+        , A.toJSON nSrc
         , A.toJSON nEntries
         , A.toJSON nTime
         , A.toJSON nAlloc

--- a/src/Profiteur/Parser.hs
+++ b/src/Profiteur/Parser.hs
@@ -15,10 +15,10 @@ import qualified Data.Vector     as V
 import qualified GHC.Prof        as Prof
 import qualified GHC.Prof.Types  as Prof
 
+import           Data.Maybe (fromMaybe)
 
 --------------------------------------------------------------------------------
 import           Profiteur.Core
-
 
 --------------------------------------------------------------------------------
 decode :: TL.Text -> Either String CostCentre
@@ -59,6 +59,7 @@ profileToCostCentre prof = do
         return CostCentre
             { ccName            = Prof.costCentreName cc
             , ccModule          = Prof.costCentreModule cc
+            , ccSrc             = fromMaybe mempty $ Prof.costCentreSrc cc
             , ccId              = T.pack (show $ no)
             , ccEntries         = fromIntegral (Prof.costCentreEntries cc)
             , ccIndividualTime  = Scientific.toRealFloat (Prof.costCentreIndTime cc)


### PR DESCRIPTION
I was profiling some slow QuickCheck generators, and all I could see was `arbitrary`. This adds the file source location to the cost-centre details box.

Resolves #29