### PR TITLE
Bump bytestring and aeson deps to allow building with GHC 9.2.3

### DIFF
--- a/profiteur.cabal
+++ b/profiteur.cabal
@@ -54,9 +54,9 @@ Executable profiteur
     Paths_profiteur
 
   Build-depends:
-    aeson                >= 0.6  && < 1.6,
+    aeson                >= 0.6  && < 2.2,
     base                 >= 4.8  && < 5,
-    bytestring           >= 0.9  && < 0.11,
+    bytestring           >= 0.9  && < 0.12,
     containers           >= 0.5  && < 0.7,
     filepath             >= 1.3  && < 1.5,
     ghc-prof             >= 1.3  && < 1.5,

--- a/src/Profiteur/Core.hs
+++ b/src/Profiteur/Core.hs
@@ -19,7 +19,6 @@ import qualified Data.Aeson          as A
 import qualified Data.HashMap.Strict as HMS
 import           Data.List           (foldl')
 import           Data.Maybe          (mapMaybe, maybeToList)
-import           Data.Monoid         ((<>))
 import qualified Data.Text           as T
 import qualified Data.Vector         as V
 


### PR DESCRIPTION
While there, fix an "unused import" warning.

Fixes #33 