### PR TITLE
Auto expand nodes until the first branch

### DIFF
--- a/data/js/main.js
+++ b/data/js/main.js
@@ -13,6 +13,16 @@ function main() {
     var tm = new TreeMap(rc, selection, sorting, zoom);
     var details = new Details($('#details'), selection, sorting, zoom);
     selection.setSelectedNode(root);
+
+    let currentNode = root;
+    currentNode.select();
+    currentNode.setExpanded(true);
+    while(currentNode.children.length == 1) {
+        currentNode = currentNode.children[0];
+        currentNode.select();
+        currentNode.setExpanded(true);
+    }
+    tb.scrollToNode(currentNode, true);
 }
 
 $(document).ready(function () {

--- a/data/js/tree-browser.js
+++ b/data/js/tree-browser.js
@@ -63,7 +63,7 @@ TreeBrowser.prototype.renderNode = function(element, node) {
     }
 };
 
-TreeBrowser.prototype.scrollToNode = function(node) {
+TreeBrowser.prototype.scrollToNode = function(node, force) {
     var element  = this.elements[node.id];
     var position = element.position();
     var top      = this.container.scrollTop();
@@ -71,7 +71,7 @@ TreeBrowser.prototype.scrollToNode = function(node) {
     var height   = this.container.height();
     var width    = this.container.width();
 
-    if (position.top < 0 || position.top >= height ||
+    if (force || position.top < 0 || position.top >= height ||
             position.left < 0 || position.left >= width) {
         this.container.scrollTop(top + position.top - height / 2);
         this.container.scrollLeft(left + position.left);


### PR DESCRIPTION
There are almost always numerous single-child nodes at the top of the profile which you need to click through to get anywhere useful. This skips those nodes when opening a profile and takes you to the first node with multiple children. If you're using criterion for example, this saves around 12 useless clicks.