### PR TITLE
Expose two modules as a library

### DIFF
--- a/profiteur.cabal
+++ b/profiteur.cabal
@@ -40,6 +40,36 @@ Source-repository head
   Type: git
   Location: git://github.com/jaspervdj/profiteur.git
 
+Library
+  Default-language: Haskell2010
+  Ghc-options:      -Wall
+  Hs-source-dirs:   src
+  Exposed-Modules:
+    Profiteur.Core
+    Profiteur.Parser
+  Other-modules:
+    Profiteur.DataFile
+    Profiteur.DataFile.Internal
+    Paths_profiteur
+  Build-depends:
+    aeson                >= 0.6  && < 2.2,
+    base                 >= 4.8  && < 5,
+    bytestring           >= 0.9  && < 0.12,
+    containers           >= 0.5  && < 0.7,
+    ghc-prof             >= 1.3  && < 1.5,
+    js-jquery            >= 3.1  && < 3.4,
+    scientific           >= 0.3  && < 0.4,
+    text                 >= 0.11 && < 2.1,
+    unordered-containers >= 0.2  && < 0.3,
+    vector               >= 0.10 && < 0.13
+  if flag(embed-data-files)
+    Hs-source-dirs: src/embed
+    Build-depends:
+      file-embed       >= 0.0.10 && < 0.0.12,
+      template-haskell
+  else
+    Hs-source-dirs: src/noembed
+
 Executable profiteur
   Default-language: Haskell2010
   Ghc-options:      -Wall

--- a/src/Profiteur/Parser.hs
+++ b/src/Profiteur/Parser.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Profiteur.Parser
     ( decode
+    , profileToCostCentre
     ) where
 
 


### PR DESCRIPTION
Hey @jaspervdj!

Long time no chat! Me and @adamgundry have been working on integrating Profiteur's renderer [into eventlog2html](https://github.com/adamgundry/eventlog2html/pull/3), and in order to do that, we piggybacked on the `profileToCostCentre` function and the `NodeMap` data structure. In order to import those from `eventlog2html`, we had to add a `library` stanza to the `.cabal` file and expose the `profileToCostCentre` function, which is what this PR does.

Let us know what you think!